### PR TITLE
Keep token in webview so we can set the token after users do "open in browser" or copy-paste the link

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@material-ui/icons": "^4.11.3",
+    "@vercel/analytics": "^1.1.1",
     "@yudiel/react-qr-scanner": "^1.1.10",
     "autoprefixer": "10.4.16",
     "cookie": "^0.6.0",
@@ -41,7 +42,6 @@
     "@types/node": "18.17.19",
     "@types/react": "18.2.37",
     "@types/react-dom": "18.2.15",
-    "@vercel/analytics": "^1.1.1",
     "@types/invariant": "^2.2.36",
     "@types/lodash.debounce": "^4.0.9",
     "@types/node-schedule": "^2.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@material-ui/icons':
     specifier: ^4.11.3
     version: 4.11.3(@material-ui/core@4.12.4)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
+  '@vercel/analytics':
+    specifier: ^1.1.1
+    version: 1.1.1
   '@yudiel/react-qr-scanner':
     specifier: ^1.1.10
     version: 1.2.0(react-dom@18.2.0)(react@18.2.0)
@@ -97,9 +100,6 @@ devDependencies:
   '@types/react-window':
     specifier: ^1.8.8
     version: 1.8.8
-  '@vercel/analytics':
-    specifier: ^1.1.1
-    version: 1.1.1
   husky:
     specifier: ^8.0.0
     version: 8.0.3
@@ -612,7 +612,7 @@ packages:
     resolution: {integrity: sha512-+NqgNmSabg3IFfxYhrWCfB/H+RCUOCR5ExRudNG2+pcRehq628DJB5e1u1xqwpLtn4pAYii4D98w7kofORAGQA==}
     dependencies:
       server-only: 0.0.1
-    dev: true
+    dev: false
 
   /@yudiel/react-qr-scanner@1.2.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-AwOshTcVieVlHjkFH/QfGNj8gTMlel6HHAHWHrkOpcPDnxwSw2yfy1PRCmsjMfH5UywJ2SwMIxI/AqjVavdCog==}
@@ -3283,7 +3283,7 @@ packages:
 
   /server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
-    dev: true
+    dev: false
 
   /set-function-length@1.1.1:
     resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,10 +14,24 @@ import {
   MusicPlayer,
   RSVPWishesSection,
 } from "@/modules/Home";
+import { reviewRSVPSession } from "@/modules/RSVP/components/RSVPSessionCookies";
 
-type HomeProps = {};
+type HomeProps = {
+  searchParams: {
+    /**
+     * RSVP token
+     */
+    t?: string;
+    /**
+     * means client must check whether the cookies exist before proceeding to set the cookies again
+     */
+    c?: string;
+  };
+};
 
-export default async function Home(_: HomeProps) {
+export default async function Home({ searchParams }: HomeProps) {
+  await reviewRSVPSession(searchParams);
+
   const rsvpViewModel = await getRSVPViewModel();
 
   const rsvpContextValue: RSVPContextValue = !rsvpViewModel.isValidRSVP

--- a/src/app/rsvp/route.ts
+++ b/src/app/rsvp/route.ts
@@ -26,25 +26,43 @@ export async function GET(request: Request) {
     id: tokenData.id,
   });
 
+  const redirectURL = new URL("/", request.url);
+
+  if (
+    // no token from param
+    !url.searchParams.has("c") ||
+    // token from param & cookies are diff, so we need to keep setting the params
+    url.searchParams.has("d")
+  ) {
+    redirectURL.searchParams.set("t", rsvpToken); // pass the token to the client as param
+    redirectURL.searchParams.set("c", "1"); // means client must check whether the cookies exist before proceeding to set the cookies again
+  }
+
   // NOTE: https://github.com/vercel/next.js/discussions/48434#discussioncomment-7843884
   // Issue: https://github.com/wisnuprama/my-wedding-site/issues/46
   // workaround solution
-  const response = new Response("<script>window.location.href = '/'</script>", {
-    status: 200,
-    headers: {
-      "Content-Type": "text/html", // Setting the response type as text/html
-      "Set-Cookie": cookie.serialize("ws_r", rsvpToken, {
-        httpOnly: true,
-        secure: true,
-        sameSite: "strict",
-        path: "/",
+  const headers = new Headers();
+  headers.set("Content-Type", "text/html");
+  headers.append(
+    "Set-Cookie",
+    cookie.serialize("ws_r", rsvpToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "strict",
+      path: "/",
 
-        // 10 years
-        expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365 * 10),
-        maxAge: 60 * 60 * 24 * 365 * 10,
-      }),
+      // 10 years
+      expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365 * 10),
+      maxAge: 60 * 60 * 24 * 365 * 10,
+    }),
+  );
+  const response = new Response(
+    `<script>window.location.href = '${redirectURL.toString()}'</script>`,
+    {
+      status: 200,
+      headers,
     },
-  });
+  );
   // const response = NextResponse.redirect(new URL("/", request.url));
   // response.cookies.set("ws_r", rsvpToken, {
   //   httpOnly: true,

--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -10,14 +10,14 @@ export function evalOnce<T>(fn: () => T): () => T {
   };
 }
 
-export function callOnce(fn: () => void): () => void {
+export function callOnce<T extends (...args: any) => void>(fn: T): T {
   let called = false;
 
-  return () => {
+  return ((...args: any) => {
     if (called) {
       return;
     }
 
-    fn();
-  };
+    fn(...args);
+  }) as T;
 }

--- a/src/modules/RSVP/components/RSVPSessionCookies/index.tsx
+++ b/src/modules/RSVP/components/RSVPSessionCookies/index.tsx
@@ -1,0 +1,74 @@
+import { redirect } from "next/navigation";
+import { RSVPTokenManager } from "../../RSVPTokenManager";
+
+type SearchParams = {
+  /**
+   * RSVP token
+   */
+  t?: string;
+  /**
+   * means client must check whether the cookies exist before proceeding to set the cookies again
+   */
+  c?: string;
+};
+
+/**
+ * To decide whether to set the cookies or not after webview redirection
+ * @param searchParams
+ * @returns Promise<void | never> - if the cookies already exist, it will return void, otherwise it will redirect to the home page
+ */
+export async function reviewRSVPSession(
+  searchParams?: SearchParams,
+): Promise<void | never> {
+  if (!searchParams) {
+    return;
+  }
+
+  const { t, c } = searchParams;
+
+  // default when no params, continue with normal flow
+  if (!t && !c) {
+    return;
+  }
+
+  // clean up invalid request params
+  if (!t || !c) {
+    return redirect("/");
+  }
+
+  const rsvpTokenManager = new RSVPTokenManager();
+
+  const cookieRSVPToken = rsvpTokenManager.getTokenFromCookie();
+  const isSameToken = cookieRSVPToken === t;
+
+  // if different then proceed with the given token
+  if (cookieRSVPToken && isSameToken) {
+    const [isCookieValid] =
+      await rsvpTokenManager.verifyAndDecodeToken(cookieRSVPToken);
+    if (isCookieValid) {
+      // ignore if the cookies already exist and valid
+      return;
+    }
+
+    // invalid, so clear cookie and proceed with the given token
+    rsvpTokenManager.clearTokenCookie();
+  }
+
+  const rsvpToken = t;
+  const [isValid] = await rsvpTokenManager.verifyAndDecodeToken(rsvpToken);
+
+  if (!isValid) {
+    redirect("/");
+  }
+
+  // edge case when the cookies & the given token are diff
+  // e.g. opening diff link from telegram + webview + opening diff RSVP URL
+  // in this case we will prioritize the given token and need to make sure
+  // that when they click "Open in Browser" it will open the correct & latest RSVP token.
+  let shouldKeepC = "";
+  if (cookieRSVPToken && !isSameToken) {
+    shouldKeepC = "&d=1";
+  }
+
+  redirect(`/rsvp?t=${rsvpToken}&c=1` + shouldKeepC);
+}


### PR DESCRIPTION
Resolves #44

## Solution

1. When open RSVP for the first time, it will always add params `t` and `c` to `/` URL (e.g. `https://wedding.com?t=abc&c=1` which we will call this as home page next). `t` is the token and `c` means next time we refresh/URL is opened in diff browser, it will have to check whether there is a cookies or not
2. In home page, we will review the session.
     1. If no t and no c, then it should be normal flow, continue opening home page
     2. if no t or no c, then invalid. In this case, we will redirect to home page without params
     3. because there is c, then we will check the validity of the token from cookies
         1. if valid and the token `t` and token cookies are the same, then continue with normal flow without removing the `searchParams`
         2. Otherwise clear the token from cookies and prioritize the `t`
      4. Check the validity of `t`
      5. If invalid, then redirect to home page without params
      6. Otherwise redirect the traffic to `/rsvp?t=abc&c=1` and follow the normal flow

There might be an edge case where users open diff token

1. token cookies = abc
2. https://wedding.com?t=cda

In this case we will prioritize 2 instead of cookies and adding searchParams `d=1` to indicate that we have to consider & repeat from step 1.  
